### PR TITLE
feat: add reusable terraform provider workflows

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,13 +33,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - if: ${{ inputs.release }}
         name: GPG Agent Setup
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@v7
         with:
           git_committer_name: dangernoodle build bot
           git_committer_email: build-bot@dangernoodle.io
@@ -52,12 +52,12 @@ jobs:
 
       - if: ${{ inputs.release }}
         name: SSH Agent Setup
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.BUILD_BOT_SSH_PRIVATE_KEY }}
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 21
@@ -67,7 +67,7 @@ jobs:
           server-password: MAVEN_CENTRAL_TOKEN
 
       - name: Setup Maven
-        uses: stCarolas/setup-maven@v5
+        uses: stCarolas/setup-maven@v5.1
         with:
           maven-version: ${{ inputs.maven-version }}
 

--- a/.github/workflows/terraform-provider-release.yml
+++ b/.github/workflows/terraform-provider-release.yml
@@ -1,0 +1,38 @@
+name: terraform-provider-release
+
+on:
+  workflow_call:
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v7
+        id: import_gpg
+        with:
+          git_committer_name: dangernoodle build bot
+          git_committer_email: build-bot@dangernoodle.io
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
+          git_user_signingkey: true
+          gpg_private_key: ${{ secrets.BUILD_BOT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.BUILD_BOT_GPG_PASSPHRASE }}
+          trust_level: 5
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.github/workflows/terraform-provider-test.yml
+++ b/.github/workflows/terraform-provider-test.yml
@@ -1,0 +1,86 @@
+name: terraform-provider-test
+
+on:
+  workflow_call:
+    inputs:
+      enable-coveralls:
+        default: true
+        description: Enable Coveralls
+        required: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - run: go mod download
+      - run: go build -v .
+      - name: Run linters
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: latest
+
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_wrapper: false
+      - run: make generate
+      - name: git diff
+        run: |
+          git diff --compact-summary --exit-code || \
+            (echo; echo "Unexpected difference in directories after code generation. Run 'make generate' command and commit."; exit 1)
+
+  test:
+    name: Terraform Provider Acceptance Tests
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        terraform:
+          - '1.8.*'
+          - '1.9.*'
+          - '1.10.*'
+          - '1.11.*'
+          - '1.12.*'
+          - '1.13.*'
+          - '1.14.*'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: ${{ matrix.terraform }}
+          terraform_wrapper: false
+      - run: go mod download
+      - env:
+          TF_ACC: "1"
+          COVERALLS_API_TOKEN: ${{ secrets.COVERALLS_API_TOKEN }}
+        run: go test -v -coverprofile=coverage.out ./internal/provider/
+        timeout-minutes: 10
+      - if: inputs.enable-coveralls && matrix.terraform == '1.14.*'
+        name: Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          file: coverage.out

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,59 @@
+# dangernoodle-github
+
+Central repository for reusable GitHub Actions workflows in the dangernoodle org.
+
+## Purpose
+
+Hosts shared workflows consumed via `workflow_call` from other repos.
+
+## Workflows
+
+### `.github/workflows/maven.yml`
+
+Reusable Maven CI/CD workflow. Key inputs:
+
+| Input | Default | Notes |
+|---|---|---|
+| `maven-goals` | *(required)* | e.g. `verify`, `deploy` |
+| `maven-version` | `3.9.9` | |
+| `maven-args` | `''` | Extra flags |
+| `enable-coveralls` | `true` | Code coverage reporting |
+| `release` | `false` | Enables GPG signing + Maven Central publish |
+
+**Release mode** requires org secrets:
+- `BUILD_BOT_GPG_PRIVATE_KEY` / `BUILD_BOT_GPG_PASSPHRASE` — signs commits/tags
+- `BUILD_BOT_SSH_PRIVATE_KEY` — pushes release commits
+- `BUILD_BOT_CENTRAL_USER` / `BUILD_BOT_CENTRAL_TOKEN` — Maven Central publish
+
+Runtime: Java 21 (Temurin), Ubuntu latest.
+
+### `.github/workflows/terraform-provider-test.yml`
+
+Reusable Terraform provider CI workflow. Runs build, lint, generate diff check, and
+acceptance tests across Terraform 1.8–1.14. Matrix floor is 1.8 (provider functions
+support). Coverage uploaded to Coveralls on 1.14 only.
+
+| Input | Default | Notes |
+|---|---|---|
+| `enable-coveralls` | `true` | Set `false` for repos not using Coveralls |
+
+### `.github/workflows/terraform-provider-release.yml`
+
+Reusable Terraform provider release workflow. Runs GoReleaser with GPG signing.
+
+Requires org secrets: `BUILD_BOT_GPG_PRIVATE_KEY`, `BUILD_BOT_GPG_PASSPHRASE`.
+
+## Conventions
+
+- Workflows must use `workflow_call` trigger to be reusable
+- Callers reference as `dangernoodle-io/.github/.github/workflows/<file>.yml@main`
+  (repo is `.github` on GitHub, checked out locally as `dangernoodle-github`)
+- `secrets: inherit` at call site — no explicit secret declarations needed
+- Keep workflows generic — no repo-specific logic here
+
+## Maintenance
+
+When adding or modifying a workflow:
+1. Update `README.md` — document all inputs/outputs and include a caller snippet.
+   Keep the `## GitHub Slack App` section unchanged.
+2. Update this file (`CLAUDE.md`) with concise, relevant details about the workflow.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,74 @@
 ## Reusable Workflows
 
-- `workflows/maven.yml`: maven builds and releases
+Shared GitHub Actions workflows consumed by other `dangernoodle-io` repositories.
+
+### `maven.yml`
+
+Builds and optionally releases Maven projects.
+
+**Inputs**
+
+| Input | Type | Default | Description |
+|---|---|---|---|
+| `maven-goals` | string | — | Maven goal(s) to run (required) |
+| `maven-args` | string | `''` | Additional Maven arguments |
+| `maven-version` | string | `3.9.9` | Maven version |
+| `enable-coveralls` | boolean | `true` | Upload coverage to Coveralls |
+| `release` | boolean | `false` | Enable release mode (GPG + SSH setup, Maven Central deploy) |
+
+**Usage**
+
+```yaml
+jobs:
+  build:
+    uses: dangernoodle-io/.github/.github/workflows/maven.yml@main
+    with:
+      maven-goals: verify
+    secrets: inherit
+```
+
+---
+
+### `terraform-provider-test.yml`
+
+Runs build, lint, code generation diff check, and acceptance tests across a Terraform version matrix (1.8–1.14).
+
+**Inputs**
+
+| Input | Type | Default | Description |
+|---|---|---|---|
+| `enable-coveralls` | boolean | `true` | Upload coverage to Coveralls (runs on 1.14 only) |
+
+**Usage**
+
+```yaml
+jobs:
+  test:
+    uses: dangernoodle-io/.github/.github/workflows/terraform-provider-test.yml@main
+    secrets: inherit
+```
+
+---
+
+### `terraform-provider-release.yml`
+
+Releases a Terraform provider via GoReleaser with GPG signing.
+
+**Usage**
+
+```yaml
+jobs:
+  release:
+    uses: dangernoodle-io/.github/.github/workflows/terraform-provider-release.yml@main
+    secrets: inherit
+```
+
+---
 
 ## GitHub Slack App
 ```
 /github subscribe dangernoodle-io/<repo>
 
-/github subscribe dangernoodle-io/<repo> 
+/github subscribe dangernoodle-io/<repo>
     workflows:{event:"pull_request, workflow_dispatch", "push" branch:"main"}
 ```


### PR DESCRIPTION
- terraform-provider-test.yml: build, lint, acceptance tests across
  Terraform 1.8–1.14, optional Coveralls upload
- terraform-provider-release.yml: GoReleaser with GPG signing

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
