### PR TITLE
fix: clean up terraform-provider-test workflow

### DIFF
--- a/.github/workflows/terraform-provider-test.yml
+++ b/.github/workflows/terraform-provider-test.yml
@@ -14,7 +14,6 @@ permissions:
 
 jobs:
   build:
-    name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -42,6 +41,8 @@ jobs:
         with:
           terraform_wrapper: false
       - run: make generate
+        env:
+          GOTOOLCHAIN: auto
       - name: git diff
         run: |
           git diff --compact-summary --exit-code || \
@@ -76,7 +77,6 @@ jobs:
       - run: go mod download
       - env:
           TF_ACC: "1"
-          COVERALLS_API_TOKEN: ${{ secrets.COVERALLS_API_TOKEN }}
         run: go test -v -coverprofile=coverage.out ./internal/provider/
         timeout-minutes: 10
       - if: inputs.enable-coveralls && matrix.terraform == '1.14.*'


### PR DESCRIPTION
- remove redundant job name label from build job
- remove COVERALLS_API_TOKEN env var (github-action uses GitHub token)
- set GOTOOLCHAIN=auto on generate step to fix Dependabot failures
  when go.mod requires a newer Go version than the runner default

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
