### PR TITLE
feat: add reusable Go workflows, consolidate release

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -1,4 +1,4 @@
-name: terraform-provider-release
+name: go-release
 
 on:
   workflow_call:

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,0 +1,59 @@
+name: go-test
+
+on:
+  workflow_call:
+    inputs:
+      enable-coveralls:
+        default: true
+        description: Enable Coveralls
+        required: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - run: go mod download
+      - run: go build -v ./...
+      - name: Run linters
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: latest
+
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - run: go mod download
+      - run: go test -v -coverprofile=coverage.out -timeout=120s ./...
+      - if: inputs.enable-coveralls
+        name: Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          file: coverage.out
+        env:
+          COVERALLS_API_TOKEN: ${{ secrets.COVERALLS_API_TOKEN }}
+
+  summary:
+    name: Go Tests
+    needs: [build, test]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,9 +37,17 @@ support). Coverage uploaded to Coveralls on 1.14 only.
 |---|---|---|
 | `enable-coveralls` | `true` | Set `false` for repos not using Coveralls |
 
-### `.github/workflows/terraform-provider-release.yml`
+### `.github/workflows/go-test.yml`
 
-Reusable Terraform provider release workflow. Runs GoReleaser with GPG signing.
+Reusable Go CI workflow. Runs build, lint (golangci-lint), and tests with coverage.
+
+| Input | Default | Notes |
+|---|---|---|
+| `enable-coveralls` | `true` | Set `false` for repos not using Coveralls |
+
+### `.github/workflows/go-release.yml`
+
+Reusable Go release workflow. Runs GoReleaser with GPG signing. Each calling repo provides its own `.goreleaser.yml`.
 
 Requires org secrets: `BUILD_BOT_GPG_PRIVATE_KEY`, `BUILD_BOT_GPG_PASSPHRASE`.
 

--- a/README.md
+++ b/README.md
@@ -50,16 +50,37 @@ jobs:
 
 ---
 
-### `terraform-provider-release.yml`
+### `go-test.yml`
 
-Releases a Terraform provider via GoReleaser with GPG signing.
+Runs build, lint, and tests for Go projects with optional Coveralls coverage.
+
+**Inputs**
+
+| Input | Type | Default | Description |
+|---|---|---|---|
+| `enable-coveralls` | boolean | `true` | Upload coverage to Coveralls |
+
+**Usage**
+
+```yaml
+jobs:
+  test:
+    uses: dangernoodle-io/.github/.github/workflows/go-test.yml@main
+    secrets: inherit
+```
+
+---
+
+### `go-release.yml`
+
+Releases a Go project via GoReleaser with GPG signing. Requires a `.goreleaser.yml` in the calling repo.
 
 **Usage**
 
 ```yaml
 jobs:
   release:
-    uses: dangernoodle-io/.github/.github/workflows/terraform-provider-release.yml@main
+    uses: dangernoodle-io/.github/.github/workflows/go-release.yml@main
     secrets: inherit
 ```
 


### PR DESCRIPTION
- Add go-test.yml for generic Go projects (build + lint + test + Coveralls)
- Rename terraform-provider-release.yml to go-release.yml — identical content, generic name since the workflow has no provider-specific logic

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
