### PR TITLE
feat: consolidate go-test workflow and add homebrew support to go-release

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -2,6 +2,12 @@ name: go-release
 
 on:
   workflow_call:
+    inputs:
+      homebrew:
+        default: false
+        description: Enable Homebrew tap
+        required: false
+        type: boolean
 
 permissions:
   contents: write
@@ -29,6 +35,11 @@ jobs:
           gpg_private_key: ${{ secrets.BUILD_BOT_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.BUILD_BOT_GPG_PASSPHRASE }}
           trust_level: 5
+      - if: ${{ inputs.homebrew }}
+        name: SSH Agent Setup
+        uses: webfactory/ssh-agent@v0.10.0
+        with:
+          ssh-private-key: ${{ secrets.BUILD_BOT_SSH_PRIVATE_KEY }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
@@ -36,3 +47,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          HOMEBREW: ${{ inputs.homebrew }}

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -13,9 +13,9 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  verify:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -28,18 +28,6 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           version: latest
-
-  test:
-    needs: build
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-      - run: go mod download
       - run: go test -v -coverprofile=coverage.out -timeout=120s ./...
       - if: inputs.enable-coveralls
         name: Coveralls
@@ -48,12 +36,3 @@ jobs:
           file: coverage.out
         env:
           COVERALLS_API_TOKEN: ${{ secrets.COVERALLS_API_TOKEN }}
-
-  summary:
-    name: Go Tests
-    needs: [build, test]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
-        run: exit 1


### PR DESCRIPTION
- merge build, test, and summary jobs into single verify job in go-test.yml
- increase timeout to 15 minutes and eliminate job dependencies
- add homebrew input to go-release workflow (default: false)
- conditionally run SSH agent setup when homebrew is enabled
- pass HOMEBREW flag to goreleaser environment

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
