### PR TITLE
refactor: rename job key from verify to build in go-build.yml

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 jobs:
-  verify:
+  build:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
- aligns job naming with workflow name
- improves consistency across reusable workflows

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
