### PR TITLE
feat: add reusable plugin-test workflow

### DIFF
--- a/.github/workflows/plugin-test.yml
+++ b/.github/workflows/plugin-test.yml
@@ -1,0 +1,30 @@
+name: plugin-test
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        default: '20'
+        description: Node.js version for test runner
+        required: false
+        type: string
+      plugin-path:
+        default: 'plugin'
+        description: Path to plugin directory (contains tests/run.sh)
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+      - name: Run plugin tests
+        run: bash ${{ inputs.plugin-path }}/tests/run.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,15 @@ Reusable Go release workflow. Runs GoReleaser with GPG signing. Each calling rep
 
 Requires org secrets: `BUILD_BOT_GPG_PRIVATE_KEY`, `BUILD_BOT_GPG_PASSPHRASE`.
 
+### `.github/workflows/plugin-test.yml`
+
+Reusable Claude Code plugin test workflow. Runs `tests/run.sh` inside the plugin directory using Node.js built-in `node:test` runner. Zero npm deps required.
+
+| Input | Default | Notes |
+|---|---|---|
+| `node-version` | `'20'` | Node.js version for test runner |
+| `plugin-path` | `'plugin'` | Path to plugin directory (must contain `tests/run.sh`) |
+
 ## Conventions
 
 - Workflows must use `workflow_call` trigger to be reusable

--- a/README.md
+++ b/README.md
@@ -94,6 +94,27 @@ jobs:
 
 ---
 
+### `plugin-test.yml`
+
+Runs tests for Claude Code plugins using Node.js built-in `node:test` runner. Executes `tests/run.sh` in the plugin directory.
+
+**Inputs**
+
+| Input | Type | Default | Description |
+|---|---|---|---|
+| `node-version` | string | `'20'` | Node.js version for test runner |
+| `plugin-path` | string | `'plugin'` | Path to plugin directory (must contain `tests/run.sh`) |
+
+**Usage**
+
+```yaml
+jobs:
+  plugin-tests:
+    uses: dangernoodle-io/.github/.github/workflows/plugin-test.yml@main
+```
+
+---
+
 ## GitHub Slack App
 ```
 /github subscribe dangernoodle-io/<repo>


### PR DESCRIPTION
reusable workflow for claude code plugin tests. contract: caller
provides `<plugin-path>/tests/run.sh`, workflow handles checkout +
node setup + invocation. uses node:test built-in, zero npm deps.

inputs: node-version (default '20'), plugin-path (default 'plugin')

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
