### PR TITLE
feat: add marketplace-update composite action

### DIFF
--- a/.github/actions/marketplace-update/action.yml
+++ b/.github/actions/marketplace-update/action.yml
@@ -1,0 +1,58 @@
+name: marketplace-update
+description: Update dangernoodle-marketplace manifest with new plugin ref and push signed commit
+
+inputs:
+  plugin-name:
+    description: Name matching an entry in .claude-plugin/marketplace.json
+    required: true
+  ref:
+    description: Git tag/ref to set (e.g. v0.3.1)
+    required: true
+  ssh-private-key:
+    description: SSH private key for marketplace repo access
+    required: true
+  gpg-private-key:
+    description: GPG private key for signing commits
+    required: true
+  gpg-passphrase:
+    description: GPG passphrase for unlocking the private key
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@v7
+      with:
+        git_committer_name: dangernoodle build bot
+        git_committer_email: build-bot@dangernoodle.io
+        git_commit_gpgsign: true
+        trust_level: 5
+        gpg_private_key: ${{ inputs.gpg-private-key }}
+        passphrase: ${{ inputs.gpg-passphrase }}
+
+    - name: Set up SSH agent
+      uses: webfactory/ssh-agent@v0.9.0
+      with:
+        ssh-private-key: ${{ inputs.ssh-private-key }}
+
+    - name: Update marketplace manifest
+      shell: bash
+      run: |
+        git clone git@github.com:dangernoodle-io/dangernoodle-marketplace.git marketplace-repo
+        cd marketplace-repo
+
+        # Update marketplace.json: set source.ref for matching plugin
+        jq_filter="(.[] | select(.name == \"${{ inputs.plugin-name }}\") | .source.ref) |= \"${{ inputs.ref }}\""
+        jq "$jq_filter" .claude-plugin/marketplace.json > marketplace.json.tmp
+        mv marketplace.json.tmp .claude-plugin/marketplace.json
+
+        # Check if there are changes
+        if git diff --quiet .claude-plugin/marketplace.json; then
+          echo "No changes to marketplace.json for ${{ inputs.plugin-name }}"
+          exit 0
+        fi
+
+        git add .claude-plugin/marketplace.json
+        git commit -S -m "chore: bump ${{ inputs.plugin-name }} to ${{ inputs.ref }}"
+        git push origin main

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -8,6 +8,16 @@ on:
         description: Enable Homebrew tap
         required: false
         type: boolean
+      marketplace:
+        default: false
+        description: Update dangernoodle-marketplace ref after release
+        required: false
+        type: boolean
+      plugin-name:
+        default: ''
+        description: Plugin name in marketplace.json (required when marketplace=true)
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -44,3 +54,18 @@ jobs:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           HOMEBREW: ${{ inputs.homebrew }}
           SSH_PRIVATE_KEY: ${{ inputs.homebrew && secrets.BUILD_BOT_SSH_PRIVATE_KEY || '' }}
+      - name: Checkout workflows repo for marketplace-update action
+        if: inputs.marketplace
+        uses: actions/checkout@v6
+        with:
+          repository: dangernoodle-io/.github
+          path: .github-workflows-src
+      - name: Update marketplace
+        if: inputs.marketplace
+        uses: ./.github-workflows-src/.github/actions/marketplace-update
+        with:
+          plugin-name: ${{ inputs.plugin-name }}
+          ref: ${{ github.ref_name }}
+          ssh-private-key: ${{ secrets.BUILD_BOT_SSH_PRIVATE_KEY }}
+          gpg-private-key: ${{ secrets.BUILD_BOT_GPG_PRIVATE_KEY }}
+          gpg-passphrase: ${{ secrets.BUILD_BOT_GPG_PASSPHRASE }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,8 +52,10 @@ Reusable Go release workflow. Runs GoReleaser with GPG signing. Each calling rep
 | Input | Default | Notes |
 |---|---|---|
 | `homebrew` | `false` | Publish Homebrew formula to tap repo |
+| `marketplace` | `false` | Update dangernoodle-marketplace ref after release |
+| `plugin-name` | `''` | Plugin name in marketplace.json (required when marketplace=true) |
 
-Requires org secrets: `BUILD_BOT_GPG_PRIVATE_KEY`, `BUILD_BOT_GPG_PASSPHRASE`.
+Requires org secrets: `BUILD_BOT_GPG_PRIVATE_KEY`, `BUILD_BOT_GPG_PASSPHRASE`. When using marketplace mode, also requires `BUILD_BOT_SSH_PRIVATE_KEY`.
 
 ### `.github/workflows/plugin-test.yml`
 
@@ -63,6 +65,22 @@ Reusable Claude Code plugin test workflow. Runs `tests/run.sh` inside the plugin
 |---|---|---|
 | `node-version` | `'20'` | Node.js version for test runner |
 | `plugin-path` | `'plugin'` | Path to plugin directory (must contain `tests/run.sh`) |
+
+## Composite Actions
+
+### `.github/actions/marketplace-update`
+
+Composite action to update the dangernoodle-marketplace manifest with a new plugin ref and push a signed commit.
+
+| Input | Required | Notes |
+|---|---|---|
+| `plugin-name` | yes | Name matching an entry in `.claude-plugin/marketplace.json` |
+| `ref` | yes | Git tag/ref to set (e.g. `v0.3.1`) |
+| `ssh-private-key` | yes | SSH private key for marketplace repo access |
+| `gpg-private-key` | yes | GPG private key for signing commits |
+| `gpg-passphrase` | yes | GPG passphrase for unlocking the private key |
+
+Clones `dangernoodle-marketplace`, uses `jq` to update `.claude-plugin/marketplace.json` with the new ref, commits with GPG signing, and pushes to origin/main. Designed to be called from `go-release.yml` post-release.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Releases a Go project via GoReleaser with GPG signing. Requires a `.goreleaser.y
 | Input | Type | Default | Description |
 |---|---|---|---|
 | `homebrew` | boolean | `false` | Publish Homebrew formula to tap repo |
+| `marketplace` | boolean | `false` | Update dangernoodle-marketplace ref after release |
+| `plugin-name` | string | `''` | Plugin name in marketplace.json (required when marketplace=true) |
 
 **Usage**
 
@@ -89,6 +91,18 @@ jobs:
     uses: dangernoodle-io/.github/.github/workflows/go-release.yml@main
     with:
       homebrew: true
+    secrets: inherit
+```
+
+To update the marketplace manifest after release:
+
+```yaml
+jobs:
+  release:
+    uses: dangernoodle-io/.github/.github/workflows/go-release.yml@main
+    with:
+      marketplace: true
+      plugin-name: my-plugin
     secrets: inherit
 ```
 


### PR DESCRIPTION
- new composite action bumps dangernoodle-marketplace source.ref for a plugin and pushes a signed commit
- extend go-release.yml with marketplace + plugin-name inputs wiring the action after goreleaser
- docs: README and CLAUDE.md updated with new inputs
