### PR TITLE
fix: target .plugins[] in marketplace manifest jq filter

### DIFF
--- a/.github/actions/marketplace-update/action.yml
+++ b/.github/actions/marketplace-update/action.yml
@@ -43,7 +43,7 @@ runs:
         cd marketplace-repo
 
         # Update marketplace.json: set source.ref for matching plugin
-        jq_filter="(.[] | select(.name == \"${{ inputs.plugin-name }}\") | .source.ref) |= \"${{ inputs.ref }}\""
+        jq_filter="(.plugins[] | select(.name == \"${{ inputs.plugin-name }}\") | .source.ref) |= \"${{ inputs.ref }}\""
         jq "$jq_filter" .claude-plugin/marketplace.json > marketplace.json.tmp
         mv marketplace.json.tmp .claude-plugin/marketplace.json
 


### PR DESCRIPTION
marketplace.json is `{"name": ..., "plugins": [...]}`, not a bare array.
The previous `.[]` iterated object values (strings), causing
`Cannot index string with string "name"` and skipping the ref update.
