### PR TITLE
fix: set git author ident in marketplace-update action

### DIFF
--- a/.github/actions/marketplace-update/action.yml
+++ b/.github/actions/marketplace-update/action.yml
@@ -24,6 +24,7 @@ runs:
     - name: Import GPG key
       uses: crazy-max/ghaction-import-gpg@v7
       with:
+        git_user_signingkey: true
         git_committer_name: dangernoodle build bot
         git_committer_email: build-bot@dangernoodle.io
         git_commit_gpgsign: true
@@ -41,6 +42,9 @@ runs:
       run: |
         git clone git@github.com:dangernoodle-io/dangernoodle-marketplace.git marketplace-repo
         cd marketplace-repo
+
+        git config user.name "dangernoodle build bot"
+        git config user.email "build-bot@dangernoodle.io"
 
         # Update marketplace.json: set source.ref for matching plugin
         jq_filter="(.plugins[] | select(.name == \"${{ inputs.plugin-name }}\") | .source.ref) |= \"${{ inputs.ref }}\""


### PR DESCRIPTION
The GPG import step configures the committer identity but not the
author. `git commit` then fails with "empty ident name" when resolving
user.name/user.email. Set them explicitly on the cloned repo and
enable git_user_signingkey so the signing key is wired to user config.
