### PR TITLE
feat: reusable gh-release + auto-label-conventional workflows

### DIFF
--- a/.github/workflows/auto-label-conventional.yml
+++ b/.github/workflows/auto-label-conventional.yml
@@ -1,0 +1,31 @@
+name: auto-label-conventional
+
+on:
+  workflow_call:
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const map = [
+              [/^feat\(new-component\)/i, 'new-component'],
+              [/^feat[:(]/i, 'enhancement'],
+              [/^fix[:(]/i, 'bug'],
+            ];
+            for (const [re, label] of map) {
+              if (re.test(title)) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number,
+                  labels: [label],
+                });
+                break;
+              }
+            }

--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -1,0 +1,76 @@
+name: gh-release
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: "Tag to release. Defaults to the calling ref."
+        type: string
+        default: ""
+      assets-artifact:
+        description: "Optional artifact name whose files become release assets."
+        type: string
+        default: ""
+      notes-preamble-artifact:
+        description: "Optional artifact name containing a single markdown file prepended to auto-generated notes."
+        type: string
+        default: ""
+      wait-for-check:
+        description: "Optional check name to wait for before publishing."
+        type: string
+        default: ""
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Wait for check
+        if: inputs.wait-for-check != ''
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.sha }}
+          check-name: ${{ inputs.wait-for-check }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 20
+
+      - name: Download assets
+        if: inputs.assets-artifact != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.assets-artifact }}
+          path: release-assets
+
+      - name: Download notes preamble
+        if: inputs.notes-preamble-artifact != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.notes-preamble-artifact }}
+          path: release-preamble
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag != '' && inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          ASSETS=""
+          if [ -d release-assets ]; then
+            ASSETS=$(find release-assets -type f | tr '\n' ' ')
+          fi
+          PREAMBLE=""
+          if [ -d release-preamble ]; then
+            PREAMBLE=$(find release-preamble -type f -name '*.md' | head -n1)
+          fi
+          gh release create "$TAG" $ASSETS \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$TAG" \
+            --generate-notes \
+            ${PREAMBLE:+--notes-file "$PREAMBLE"} \
+            --verify-tag

--- a/README.md
+++ b/README.md
@@ -129,6 +129,55 @@ jobs:
 
 ---
 
+### `gh-release.yml`
+
+Publishes a GitHub release with optional assets and custom release notes preamble.
+
+**Inputs**
+
+| Input | Type | Default | Description |
+|---|---|---|---|
+| `tag` | string | `''` | Tag to release (defaults to the calling ref if empty) |
+| `assets-artifact` | string | `''` | Optional artifact name whose files become release assets |
+| `notes-preamble-artifact` | string | `''` | Optional artifact name containing a markdown file to prepend to auto-generated notes |
+| `wait-for-check` | string | `''` | Optional check name to wait for before publishing |
+
+**Usage**
+
+```yaml
+jobs:
+  release:
+    uses: dangernoodle-io/.github/.github/workflows/gh-release.yml@main
+    with:
+      tag: v1.0.0
+      assets-artifact: build-artifacts
+    secrets: inherit
+```
+
+---
+
+### `auto-label-conventional.yml`
+
+Labels pull requests based on conventional-commit prefix in the title.
+
+**Inputs**
+
+None.
+
+**Usage**
+
+```yaml
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  auto-label:
+    uses: dangernoodle-io/.github/.github/workflows/auto-label-conventional.yml@main
+```
+
+---
+
 ## GitHub Slack App
 ```
 /github subscribe dangernoodle-io/<repo>


### PR DESCRIPTION
Add two new reusable GitHub Actions workflows for general org use.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
