### PR TITLE
chore: drop wait-for-check from gh-release reusable

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -15,10 +15,6 @@ on:
         description: "Optional artifact name containing a single markdown file prepended to auto-generated notes."
         type: string
         default: ""
-      wait-for-check:
-        description: "Optional check name to wait for before publishing."
-        type: string
-        default: ""
 
 permissions:
   contents: write
@@ -30,15 +26,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Wait for check
-        if: inputs.wait-for-check != ''
-        uses: lewagon/wait-on-check-action@v1.3.4
-        with:
-          ref: ${{ github.sha }}
-          check-name: ${{ inputs.wait-for-check }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 20
 
       - name: Download assets
         if: inputs.assets-artifact != ''

--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ Publishes a GitHub release with optional assets and custom release notes preambl
 | `tag` | string | `''` | Tag to release (defaults to the calling ref if empty) |
 | `assets-artifact` | string | `''` | Optional artifact name whose files become release assets |
 | `notes-preamble-artifact` | string | `''` | Optional artifact name containing a markdown file to prepend to auto-generated notes |
-| `wait-for-check` | string | `''` | Optional check name to wait for before publishing |
 
 **Usage**
 


### PR DESCRIPTION
Remove the wait-for-check input and associated step from the gh-release
workflow. Simplified workflow focuses on publishing only.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
