### PR TITLE
feat: cover all conventional commit types in auto-label and standardize release notes

### DIFF
--- a/.github/workflows/auto-label-conventional.yml
+++ b/.github/workflows/auto-label-conventional.yml
@@ -15,8 +15,17 @@ jobs:
             const title = context.payload.pull_request.title;
             const map = [
               [/^feat\(new-component\)/i, 'new-component'],
-              [/^feat[:(]/i, 'enhancement'],
-              [/^fix[:(]/i, 'bug'],
+              [/^feat[:(]/i,     'enhancement'],
+              [/^fix[:(]/i,      'bug'],
+              [/^docs[:(]/i,     'documentation'],
+              [/^refactor[:(]/i, 'refactor'],
+              [/^perf[:(]/i,     'performance'],
+              [/^test[:(]/i,     'test'],
+              [/^chore[:(]/i,    'chore'],
+              [/^build[:(]/i,    'build'],
+              [/^ci[:(]/i,       'ci'],
+              [/^style[:(]/i,    'style'],
+              [/^revert[:(]/i,   'revert'],
             ];
             for (const [re, label] of map) {
               if (re.test(title)) {

--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -41,6 +41,35 @@ jobs:
           name: ${{ inputs.notes-preamble-artifact }}
           path: release-preamble
 
+      - name: Materialize release-notes config
+        run: |
+          mkdir -p .github
+          cat > .github/release.yml <<'EOF'
+          changelog:
+            exclude:
+              labels: [skip-changelog]
+              authors: [dependabot]
+            categories:
+              - title: New Components
+                labels: [new-component]
+              - title: New APIs
+                labels: [enhancement, feature]
+              - title: Fixes
+                labels: [bug, fix]
+              - title: Performance
+                labels: [performance]
+              - title: Refactors
+                labels: [refactor]
+              - title: Documentation
+                labels: [documentation]
+              - title: Tests
+                labels: [test]
+              - title: Build
+                labels: [build, ci]
+              - title: Other Changes
+                labels: ["*"]
+          EOF
+
       - name: Publish release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,16 @@ Reusable Claude Code plugin test workflow. Runs `tests/run.sh` inside the plugin
 | `node-version` | `'20'` | Node.js version for test runner |
 | `plugin-path` | `'plugin'` | Path to plugin directory (must contain `tests/run.sh`) |
 
+### `.github/workflows/gh-release.yml`
+
+Reusable release workflow that materializes `.github/release.yml` at runtime before invoking `gh release create --generate-notes`. Centralized config — consuming repos no longer need their own copy.
+
+Release notes categories: New Components, New APIs, Fixes, Performance, Refactors, Documentation, Tests, Build, Other Changes.
+
+### `.github/workflows/auto-label-conventional.yml`
+
+Reusable workflow that auto-labels PRs by conventional-commit type in the title. Labels all standard types: `feat(new-component)` → new-component; `feat` → enhancement; `fix` → bug; `docs` → documentation; `refactor` → refactor; `perf` → performance; `test` → test; `chore` → chore; `build` → build; `ci` → ci; `style` → style; `revert` → revert.
+
 ## Composite Actions
 
 ### `.github/actions/marketplace-update`

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ jobs:
 
 ### `gh-release.yml`
 
-Publishes a GitHub release with optional assets and custom release notes preamble.
+Publishes a GitHub release with optional assets and custom release notes preamble. Automatically materializes `.github/release.yml` at runtime to configure release notes categories, ensuring consistent categorization across all repos without per-repo config files.
 
 **Inputs**
 
@@ -157,7 +157,7 @@ jobs:
 
 ### `auto-label-conventional.yml`
 
-Labels pull requests based on conventional-commit prefix in the title.
+Labels pull requests based on conventional-commit prefix in the title. Supports all standard conventional types: `feat(new-component)`, `feat`, `fix`, `docs`, `refactor`, `perf`, `test`, `chore`, `build`, `ci`, `style`, and `revert`.
 
 **Inputs**
 


### PR DESCRIPTION
- extend auto-label-conventional.yml to label 12 conventional types
- materialize .github/release.yml at runtime in gh-release.yml
- document both workflows with full feature coverage
- consuming repos no longer need per-repo release.yml copies

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
