### PR TITLE
feat: reusable pio-test workflow

### DIFF
--- a/.github/workflows/pio-test.yml
+++ b/.github/workflows/pio-test.yml
@@ -1,0 +1,75 @@
+name: pio-test
+
+on:
+  workflow_call:
+    inputs:
+      cppcheck-apt-install:
+        default: false
+        description: Install cppcheck via apt before make check
+        required: false
+        type: boolean
+      pre-build-script:
+        default: ''
+        description: Optional shell script to run before make coverage (e.g., asset/webui build)
+        required: false
+        type: string
+      libdeps-cache-key-paths:
+        default: '**/platformio.ini'
+        description: Glob(s) to hash for the per-project libdeps cache key
+        required: false
+        type: string
+      enable-coveralls:
+        default: true
+        description: Enable Coveralls upload
+        required: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - name: Cache pip
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-pio-gcovr
+      - name: Cache PlatformIO toolchains
+        uses: actions/cache@v5
+        with:
+          path: ~/.platformio
+          key: ${{ runner.os }}-pio-${{ hashFiles('**/platformio.ini') }}
+          restore-keys: ${{ runner.os }}-pio-
+      - name: Cache PlatformIO project libdeps
+        uses: actions/cache@v5
+        with:
+          path: |
+            **/.pio/libdeps
+            **/.pio/build/**/lib*
+          key: ${{ runner.os }}-pio-libdeps-${{ hashFiles(inputs.libdeps-cache-key-paths) }}
+          restore-keys: ${{ runner.os }}-pio-libdeps-
+      - name: Install cppcheck
+        if: inputs.cppcheck-apt-install
+        run: sudo apt-get update && sudo apt-get install -y cppcheck
+      - name: Install tools
+        run: pip install platformio gcovr
+      - name: Pre-build
+        if: inputs.pre-build-script != ''
+        run: ${{ inputs.pre-build-script }}
+      - name: Static analysis
+        run: make check
+      - name: Test and coverage
+        run: make coverage
+      - name: Upload to Coveralls
+        if: inputs.enable-coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          file: gcovr-coveralls.json
+          format: coveralls

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.code-graph/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,17 @@ Reusable Go release workflow. Runs GoReleaser with GPG signing. Each calling rep
 
 Requires org secrets: `BUILD_BOT_GPG_PRIVATE_KEY`, `BUILD_BOT_GPG_PASSPHRASE`. When using marketplace mode, also requires `BUILD_BOT_SSH_PRIVATE_KEY`.
 
+### `.github/workflows/pio-test.yml`
+
+Reusable PlatformIO test workflow. Runs cppcheck + `pio test` + gcovr coverage with Coveralls upload. Caches pip (`~/.cache/pip`), PlatformIO toolchains (`~/.platformio`), and per-project libdeps (`**/.pio/libdeps`) so cJSON / Unity / framework downloads are reused across runs. Calling repo must provide a `Makefile` with `check` and `coverage` targets producing `gcovr-coveralls.json`.
+
+| Input | Default | Notes |
+|---|---|---|
+| `cppcheck-apt-install` | `false` | Set true for repos without cppcheck bundled |
+| `pre-build-script` | `''` | Shell to run before `make coverage` (e.g., webui build) |
+| `libdeps-cache-key-paths` | `**/platformio.ini` | Glob(s) hashed for libdeps cache invalidation |
+| `enable-coveralls` | `true` | Coveralls upload |
+
 ### `.github/workflows/plugin-test.yml`
 
 Reusable Claude Code plugin test workflow. Runs `tests/run.sh` inside the plugin directory using Node.js built-in `node:test` runner. Zero npm deps required.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,32 @@ jobs:
 
 ---
 
+### `pio-test.yml`
+
+Runs PlatformIO host tests + cppcheck + gcovr coverage for embedded projects (Arduino / ESP-IDF). Caches pip, PlatformIO toolchains, and per-project libdeps so cJSON / Unity / framework downloads are reused across runs.
+
+Calling repo must provide a `Makefile` with `check` (lint) and `coverage` (test + gcovr) targets. The `coverage` target should produce `gcovr-coveralls.json`.
+
+**Inputs**
+
+| Input | Type | Default | Description |
+|---|---|---|---|
+| `cppcheck-apt-install` | boolean | `false` | Install cppcheck via apt before `make check` (for repos without it bundled) |
+| `pre-build-script` | string | `''` | Shell to run before `make coverage` (e.g., asset/webui build) |
+| `libdeps-cache-key-paths` | string | `**/platformio.ini` | Glob(s) hashed for the libdeps cache key |
+| `enable-coveralls` | boolean | `true` | Upload coverage to Coveralls |
+
+**Usage**
+
+```yaml
+jobs:
+  test:
+    uses: dangernoodle-io/.github/.github/workflows/pio-test.yml@main
+    secrets: inherit
+```
+
+---
+
 ### `plugin-test.yml`
 
 Runs tests for Claude Code plugins using Node.js built-in `node:test` runner. Executes `tests/run.sh` in the plugin directory.


### PR DESCRIPTION
Adds pio-test.yml for PlatformIO host-test jobs (cppcheck, pio test,
gcovr coverage, Coveralls upload). Caches pip, PlatformIO toolchains,
and per-project libdeps so cJSON / Unity / framework downloads are
reused across runs.

Currently 4 inline copies live across breadboard, breadboard-ci-smoke,
cc3000-wifi-driver, and TaipanMiner — this consolidates the test job;
smoke matrices stay inline (matrix shape varies per repo).
